### PR TITLE
Fixed php7.3 compatability

### DIFF
--- a/Webapi/PaymentMethodManagement.php
+++ b/Webapi/PaymentMethodManagement.php
@@ -53,7 +53,7 @@ class PaymentMethodManagement implements PaymentMethodManagementInterface
     /**
      * @var ConfigInterface
      */
-    private ConfigInterface $configService;
+    private $configService;
 
     /**
      * @param CheckoutPaymentMethodManagementInterface $paymentMethodManagement


### PR DESCRIPTION
Left a php7.3 incompatible feature in the previous [pull-request](https://github.com/cmdotcom-plugins/pay-ext-magento2/pull/16)

